### PR TITLE
Standardize `rctv_InputSite` vs `rctv_strSiteID`, etc.

### DIFF
--- a/R/aaa-shared.R
+++ b/R/aaa-shared.R
@@ -71,12 +71,6 @@
 #'   returns a stacked summary of analysis pipeline output.
 #' @param rctv_gtObject `reactive gt_table` A [shiny::reactive()] object that
 #'   returns a [gt::gt()] object.
-#' @param rctv_InputMetric `reactive character` A [shiny::reactive()] object
-#'   that returns the `MetricID` of the selected metric.
-#' @param rctv_InputParticipant `reactive character` A [shiny::reactive()]
-#'   object that returns the `SubjectID` of the selected participant.
-#' @param rctv_InputSite `reactive character` A [shiny::reactive()] object that
-#'   returns the `GroupID` of the selected site.
 #' @param rctv_lData `reactive list` A [shiny::reactive()] object that returns a
 #'   named list of dataframes.
 #' @param rctv_lMetric `reactive list` A [shiny::reactive()] object that returns

--- a/R/gsmApp_Server.R
+++ b/R/gsmApp_Server.R
@@ -37,29 +37,29 @@ gsmApp_Server <- function(
     # Shared Reactives ----
 
     ## Inputs pass to modules (etc) as reactives.
-    rctv_InputMetric <- reactive(input$metric)
-    rctv_InputSite <- reactive(input$site)
-    rctv_InputParticipant <- reactive(input$participant)
-    rctv_InputPrimaryNavBar <- reactive(input$primary_nav_bar)
+    rctv_strMetricID <- reactive(input$metric)
+    rctv_strSiteID <- reactive(input$site)
+    rctv_strSubjectID <- reactive(input$participant)
+    rctv_strPrimaryNavBar <- reactive(input$primary_nav_bar)
 
     ## The listified dfMetrics are used by both metric sub-mods, so calculate
     ## them once. This can/should move inside a single metric-tab module.
     rctv_lMetric_base <- srvr_rctv_lMetric_base(
       dfMetrics,
-      rctv_InputMetric,
+      rctv_strMetricID,
       session
     )
     rctv_lMetric <- srvr_rctv_lMetric(
       dfMetrics,
       rctv_lMetric_base,
-      rctv_InputMetric,
-      rctv_InputSite,
+      rctv_strMetricID,
+      rctv_strSiteID,
       session
     )
     dfParticipantGroups <- make_dfParticipantGroups(dfAnalyticsInput)
     rctv_chrParticipantIDs <- srvr_rctv_chrParticipantIDs(
       dfParticipantGroups,
-      rctv_InputSite
+      rctv_strSiteID
     )
 
     # Tab Contents ----
@@ -71,7 +71,7 @@ gsmApp_Server <- function(
       dfGroups = dfGroups,
       dfMetrics = dfMetrics,
       dfBounds = dfBounds,
-      rctv_strSiteID = rctv_InputSite
+      rctv_strSiteID = rctv_strSiteID
     )
 
     # Use clickCounter to update main GroupID and MetricID inputs + tab
@@ -114,15 +114,15 @@ gsmApp_Server <- function(
     srvr_SyncTab(
       "primary_nav_bar",
       "Metric Details",
-      rctv_InputMetric,
-      rctv_InputPrimaryNavBar,
+      rctv_strMetricID,
+      rctv_strPrimaryNavBar,
       session
     )
     srvr_SyncTab(
       "primary_nav_bar",
       "Metric Details",
-      rctv_InputSite,
-      rctv_InputPrimaryNavBar,
+      rctv_strSiteID,
+      rctv_strPrimaryNavBar,
       session
     )
     rctv_strMetricDetailsGroup <- mod_MetricDetails_Server(
@@ -131,23 +131,23 @@ gsmApp_Server <- function(
       dfGroups = dfGroups,
       dfBounds = dfBounds,
       rctv_lMetric = rctv_lMetric,
-      rctv_strSiteID = rctv_InputSite,
-      rctv_strMetricID = rctv_InputMetric
+      rctv_strSiteID = rctv_strSiteID,
+      rctv_strMetricID = rctv_strMetricID
     )
     rctv_strSiteDetailsParticipant <- mod_SiteDetails_Server(
       "site_details",
       dfGroups = dfGroups,
       dfAnalyticsInput = dfAnalyticsInput,
-      rctv_strSiteID = rctv_InputSite,
-      rctv_strSubjectID = rctv_InputParticipant,
-      rctv_strMetricID = rctv_InputMetric,
+      rctv_strSiteID = rctv_strSiteID,
+      rctv_strSubjectID = rctv_strSubjectID,
+      rctv_strMetricID = rctv_strMetricID,
       rctv_lMetric = rctv_lMetric
     )
     srvr_SyncSelectInput("site", rctv_strMetricDetailsGroup, session)
 
     # Temporary: Update Site drop-down when one of the non-module widgets
     # changes its value without sending a full Shiny event.
-    srvr_SyncSelectInput("site", rctv_InputSite, session)
+    srvr_SyncSelectInput("site", rctv_strSiteID, session)
 
     ### Sync participant dropdown filter ----
     ###
@@ -218,13 +218,13 @@ gsmApp_Server <- function(
       "primary_nav_bar",
       "Participant Details",
       rctv_LatestParticipant,
-      rctv_InputPrimaryNavBar,
+      rctv_strPrimaryNavBar,
       session
     )
     mod_ParticipantDetails_Server(
       "participant_details",
       fnFetchData = fnFetchData,
-      rctv_strSubjectID = rctv_InputParticipant
+      rctv_strSubjectID = rctv_strSubjectID
     )
 
     ## Plugins ----
@@ -232,9 +232,9 @@ gsmApp_Server <- function(
       "plugins",
       lPlugins = lPlugins,
       fnFetchData = fnFetchData,
-      rctv_InputMetric = rctv_InputMetric,
-      rctv_InputSite = rctv_InputSite,
-      rctv_InputParticipant = rctv_InputParticipant
+      rctv_strMetricID = rctv_strMetricID,
+      rctv_strSiteID = rctv_strSiteID,
+      rctv_strSubjectID = rctv_strSubjectID
     )
   }
 }

--- a/R/mod_Plugins_Server.R
+++ b/R/mod_Plugins_Server.R
@@ -7,9 +7,9 @@ mod_Plugins_Server <- function(
   id,
   lPlugins,
   fnFetchData,
-  rctv_InputMetric,
-  rctv_InputSite,
-  rctv_InputParticipant
+  rctv_strMetricID,
+  rctv_strSiteID,
+  rctv_strSubjectID
 ) {
   moduleServer(id, function(input, output, session) {
     if (!is.null(lPlugins)) {
@@ -18,9 +18,9 @@ mod_Plugins_Server <- function(
         fnServer <- rlang::as_function(lPlugin$fnServer)
         args_available <- list(
           fnFetchData = fnFetchData,
-          rctv_InputMetric = rctv_InputMetric,
-          rctv_InputSite = rctv_InputSite,
-          rctv_InputParticipant = rctv_InputParticipant
+          rctv_strMetricID = rctv_strMetricID,
+          rctv_strSiteID = rctv_strSiteID,
+          rctv_strSubjectID = rctv_strSubjectID
         )
         args_used <- intersect(
           names(args_available),

--- a/inst/plugins/AE/mod_AE.R
+++ b/inst/plugins/AE/mod_AE.R
@@ -22,23 +22,23 @@ mod_AE_UI <- function(id) {
 mod_AE_Server <- function(
   id,
   fnFetchData,
-  rctv_InputSite,
-  rctv_InputParticipant
+  rctv_strSiteID,
+  rctv_strSubjectID
 ) {
   moduleServer(id, function(input, output, session) {
     rctv_dfSubject <- shiny::reactive({
       fnFetchData(
         "Subject",
-        strSiteID = rctv_InputSite(),
-        strSubjectID = rctv_InputParticipant()
+        strSiteID = rctv_strSiteID(),
+        strSubjectID = rctv_strSubjectID()
       ) %>%
         dplyr::select("SubjectID", "study_start_date")
     })
     rctv_dfAE <- shiny::reactive({
       dfAE <- fnFetchData(
         "AdverseEvents",
-        strSiteID = rctv_InputSite(),
-        strSubjectID = rctv_InputParticipant()
+        strSiteID = rctv_strSiteID(),
+        strSubjectID = rctv_strSubjectID()
       )
       if (NROW(dfAE)) {
         dfAE <- dfAE %>%

--- a/man/mod_Plugins_Server.Rd
+++ b/man/mod_Plugins_Server.Rd
@@ -8,9 +8,9 @@ mod_Plugins_Server(
   id,
   lPlugins,
   fnFetchData,
-  rctv_InputMetric,
-  rctv_InputSite,
-  rctv_InputParticipant
+  rctv_strMetricID,
+  rctv_strSiteID,
+  rctv_strSubjectID
 )
 }
 \arguments{
@@ -23,14 +23,14 @@ and optional \code{strSiteID} and \code{strSubjectID} and returns a data.frame. 
 \code{\link[=sample_fnFetchData]{sample_fnFetchData()}} for an example. The returned data.frame contains
 information about the named domain.}
 
-\item{rctv_InputMetric}{\verb{reactive character} A \code{\link[shiny:reactive]{shiny::reactive()}} object
-that returns the \code{MetricID} of the selected metric.}
+\item{rctv_strMetricID}{\verb{reactive character} A \code{\link[shiny:reactive]{shiny::reactive()}} object
+that returns the selected \code{MetricID}.}
 
-\item{rctv_InputSite}{\verb{reactive character} A \code{\link[shiny:reactive]{shiny::reactive()}} object that
-returns the \code{GroupID} of the selected site.}
+\item{rctv_strSiteID}{\verb{reactive character} A \code{\link[shiny:reactive]{shiny::reactive()}} object that
+returns the \code{GroupID} of a site.}
 
-\item{rctv_InputParticipant}{\verb{reactive character} A \code{\link[shiny:reactive]{shiny::reactive()}}
-object that returns the \code{SubjectID} of the selected participant.}
+\item{rctv_strSubjectID}{\verb{reactive character} A \code{\link[shiny:reactive]{shiny::reactive()}} object
+that returns the \code{SubjectID} of the selected participant.}
 }
 \value{
 Nothing yet.

--- a/man/shared-params.Rd
+++ b/man/shared-params.Rd
@@ -105,15 +105,6 @@ returns a stacked summary of analysis pipeline output.}
 \item{rctv_gtObject}{\verb{reactive gt_table} A \code{\link[shiny:reactive]{shiny::reactive()}} object that
 returns a \code{\link[gt:gt]{gt::gt()}} object.}
 
-\item{rctv_InputMetric}{\verb{reactive character} A \code{\link[shiny:reactive]{shiny::reactive()}} object
-that returns the \code{MetricID} of the selected metric.}
-
-\item{rctv_InputParticipant}{\verb{reactive character} A \code{\link[shiny:reactive]{shiny::reactive()}}
-object that returns the \code{SubjectID} of the selected participant.}
-
-\item{rctv_InputSite}{\verb{reactive character} A \code{\link[shiny:reactive]{shiny::reactive()}} object that
-returns the \code{GroupID} of the selected site.}
-
 \item{rctv_lData}{\verb{reactive list} A \code{\link[shiny:reactive]{shiny::reactive()}} object that returns a
 named list of dataframes.}
 

--- a/tests/testthat/test-mod_MetricDetails_Server.R
+++ b/tests/testthat/test-mod_MetricDetails_Server.R
@@ -1,11 +1,11 @@
 test_that("mod_MetricDetails_Server initializes and renders scatter plot", {
   # Inputs to simulate things that happen in the main server function.
-  rctv_input_metric <- reactiveVal("Analysis_kri0001")
-  rctv_input_site <- reactiveVal("None")
+  rctv_strMetricID <- reactiveVal("Analysis_kri0001")
+  rctv_strSiteID <- reactiveVal("None")
   rctv_lMetric <- reactive({
-    lMetric <- as.list(filter_byMetricID(sample_dfMetrics, rctv_input_metric()))
-    if (rctv_input_site() != "None") {
-      lMetric$selectedGroupIDs <- rctv_input_site()
+    lMetric <- as.list(filter_byMetricID(sample_dfMetrics, rctv_strMetricID()))
+    if (rctv_strSiteID() != "None") {
+      lMetric$selectedGroupIDs <- rctv_strSiteID()
     }
     lMetric
   })
@@ -18,8 +18,8 @@ test_that("mod_MetricDetails_Server initializes and renders scatter plot", {
       dfGroups = sample_dfGroups,
       dfBounds = sample_dfBounds,
       rctv_lMetric = rctv_lMetric,
-      rctv_strSiteID = rctv_input_site,
-      rctv_strMetricID = rctv_input_metric
+      rctv_strSiteID = rctv_strSiteID,
+      rctv_strMetricID = rctv_strMetricID
     ),
     {
       # Set up the return-watcher.
@@ -39,12 +39,12 @@ test_that("mod_MetricDetails_Server initializes and renders scatter plot", {
 test_that("mod_MetricDetails_Server renders tab outputs", {
   call <- rlang::current_env()
   # Inputs to simulate things that happen in the main server function.
-  rctv_input_metric <- reactiveVal("Analysis_kri0001")
-  rctv_input_site <- reactiveVal("None")
+  rctv_strMetricID <- reactiveVal("Analysis_kri0001")
+  rctv_strSiteID <- reactiveVal("None")
   rctv_lMetric <- reactive({
-    lMetric <- as.list(filter_byMetricID(sample_dfMetrics, rctv_input_metric()))
-    if (rctv_input_site() != "None") {
-      lMetric$selectedGroupIDs <- rctv_input_site()
+    lMetric <- as.list(filter_byMetricID(sample_dfMetrics, rctv_strMetricID()))
+    if (rctv_strSiteID() != "None") {
+      lMetric$selectedGroupIDs <- rctv_strSiteID()
     }
     lMetric
   })
@@ -57,8 +57,8 @@ test_that("mod_MetricDetails_Server renders tab outputs", {
       dfGroups = sample_dfGroups,
       dfBounds = sample_dfBounds,
       rctv_lMetric = rctv_lMetric,
-      rctv_strSiteID = rctv_input_site,
-      rctv_strMetricID = rctv_input_metric
+      rctv_strSiteID = rctv_strSiteID,
+      rctv_strMetricID = rctv_strMetricID
     ),
     {
       # Set up the return-watcher.

--- a/tests/testthat/test-mod_Plugins_Server.R
+++ b/tests/testthat/test-mod_Plugins_Server.R
@@ -7,23 +7,23 @@ test_that("mod_Plugins_Server outputs the expected result", {
       lPlugins = list(
         list(
           strTitle = "Plugin Test",
-          fnServer = function(id, rctv_InputParticipant) {
+          fnServer = function(id, rctv_strSubjectID) {
             moduleServer(id, function(input, output, session) {
               output$test <- shiny::renderText({
-                paste("The selected participant is", rctv_InputParticipant())
+                paste("The selected participant is", rctv_strSubjectID())
               })
             })
           }
         )
       ),
       fnFetchData = sample_fnFetchData,
-      rctv_InputMetric = reactive(NULL),
-      rctv_InputSite = reactive(NULL),
-      rctv_InputParticipant = reactiveVal("0008")
+      rctv_strMetricID = reactive(NULL),
+      rctv_strSiteID = reactive(NULL),
+      rctv_strSubjectID = reactiveVal("0008")
     ),
     {
       expect_equal(output$`1-test`, "The selected participant is 0008")
-      rctv_InputParticipant("new")
+      rctv_strSubjectID("new")
       session$flushReact()
       expect_equal(output$`1-test`, "The selected participant is new")
     }

--- a/tests/testthat/test-mod_SiteDetails_Server.R
+++ b/tests/testthat/test-mod_SiteDetails_Server.R
@@ -1,12 +1,12 @@
 test_that("mod_SiteDetails_Server renders site metadata", {
   # Inputs to simulate things that happen in the main server function.
-  rctv_input_metric <- reactiveVal("Analysis_kri0001")
-  rctv_input_site <- reactiveVal("0X003")
-  rctv_input_subject <- reactiveVal("0545")
+  rctv_strMetricID <- reactiveVal("Analysis_kri0001")
+  rctv_strSiteID <- reactiveVal("0X003")
+  rctv_strSubjectID <- reactiveVal("0545")
   rctv_lMetric <- reactive({
-    lMetric <- as.list(filter_byMetricID(sample_dfMetrics, rctv_input_metric()))
-    if (rctv_input_site() != "None") {
-      lMetric$selectedGroupIDs <- rctv_input_site()
+    lMetric <- as.list(filter_byMetricID(sample_dfMetrics, rctv_strMetricID()))
+    if (rctv_strSiteID() != "None") {
+      lMetric$selectedGroupIDs <- rctv_strSiteID()
     }
     lMetric
   })
@@ -17,9 +17,9 @@ test_that("mod_SiteDetails_Server renders site metadata", {
       id = "siteDetailsTest",
       dfGroups = sample_dfGroups,
       dfAnalyticsInput = sample_dfAnalyticsInput,
-      rctv_strSiteID = rctv_input_site,
-      rctv_strSubjectID = rctv_input_subject,
-      rctv_strMetricID = rctv_input_metric,
+      rctv_strSiteID = rctv_strSiteID,
+      rctv_strSubjectID = rctv_strSubjectID,
+      rctv_strMetricID = rctv_strMetricID,
       rctv_lMetric = rctv_lMetric
     ),
     {
@@ -31,13 +31,13 @@ test_that("mod_SiteDetails_Server renders site metadata", {
 
 test_that("mod_SiteDetails_Server renders participants table", {
   # Inputs to simulate things that happen in the main server function.
-  rctv_input_metric <- reactiveVal("Analysis_kri0001")
-  rctv_input_site <- reactiveVal("0X003")
-  rctv_input_subject <- reactiveVal("0545")
+  rctv_strMetricID <- reactiveVal("Analysis_kri0001")
+  rctv_strSiteID <- reactiveVal("0X003")
+  rctv_strSubjectID <- reactiveVal("0545")
   rctv_lMetric <- reactive({
-    lMetric <- as.list(filter_byMetricID(sample_dfMetrics, rctv_input_metric()))
-    if (rctv_input_site() != "None") {
-      lMetric$selectedGroupIDs <- rctv_input_site()
+    lMetric <- as.list(filter_byMetricID(sample_dfMetrics, rctv_strMetricID()))
+    if (rctv_strSiteID() != "None") {
+      lMetric$selectedGroupIDs <- rctv_strSiteID()
     }
     lMetric
   })
@@ -48,9 +48,9 @@ test_that("mod_SiteDetails_Server renders participants table", {
       id = "siteDetailsTest",
       dfGroups = sample_dfGroups,
       dfAnalyticsInput = sample_dfAnalyticsInput,
-      rctv_strSiteID = rctv_input_site,
-      rctv_strSubjectID = rctv_input_subject,
-      rctv_strMetricID = rctv_input_metric,
+      rctv_strSiteID = rctv_strSiteID,
+      rctv_strSubjectID = rctv_strSubjectID,
+      rctv_strMetricID = rctv_strMetricID,
       rctv_lMetric = rctv_lMetric
     ),
     {


### PR DESCRIPTION
## Overview
I want to nail down these argument names before we start telling people to use them in their plugins, so I standardized to our normal format. 

## Test Notes/Sample Code
There are a couple arguments left that still reference "input", but those are generic input-updater functions and that sort of thing.

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #331.
