### PR TITLE
Use longitudinal data

### DIFF
--- a/R/mod_BarChart.R
+++ b/R/mod_BarChart.R
@@ -71,6 +71,12 @@ Widget_BarChart <- function(
     "strOutcome is not a character" = is.character(strOutcome),
     "dfBounds is not a data.frame" = is.null(dfBounds) || is.data.frame(dfBounds)
   )
+  if (length(dfResults)) {
+    dfResults <- gsm::FilterByLatestSnapshotDate(dfResults)
+  }
+  if (length(dfBounds)) {
+    dfBounds <- gsm::FilterByLatestSnapshotDate(dfBounds)
+  }
   vThreshold <- NULL
   if (
     strOutcome == "Score" &&

--- a/R/mod_MetricDetails.R
+++ b/R/mod_MetricDetails.R
@@ -59,14 +59,19 @@ mod_MetricDetails_Server <- function(
     }) %>%
       bindCache(rctv_strMetricID())
 
+    rctv_dfBounds_Latest <- reactive({
+      gsm::FilterByLatestSnapshotDate(rctv_dfBounds_byMetricID())
+    }) %>%
+      bindCache(rctv_strMetricID())
+
     # Selections from tabs ----
 
     mod_ScatterPlot_Server(
       "scatter_plot",
-      rctv_dfResults = rctv_dfResults_byMetricID,
+      rctv_dfResults = rctv_dfResults_Latest,
       rctv_lMetric = rctv_lMetric,
       dfGroups = dfGroups,
-      rctv_dfBounds = rctv_dfBounds_byMetricID,
+      rctv_dfBounds = rctv_dfBounds_Latest,
       rctv_strSiteID = rctv_strSiteID
     )
 
@@ -85,13 +90,13 @@ mod_MetricDetails_Server <- function(
       rctv_lMetric = rctv_lMetric,
       dfGroups = dfGroups,
       strOutcome = "Score",
-      rctv_dfBounds = rctv_dfBounds_byMetricID,
+      rctv_dfBounds = rctv_dfBounds_Latest,
       rctv_strSiteID = rctv_strSiteID
     )
 
     mod_TimeSeries_Server(
       "time_series",
-      rctv_dfResults = rctv_dfResults_Latest,
+      rctv_dfResults = rctv_dfResults_byMetricID,
       rctv_lMetric = rctv_lMetric,
       dfGroups = dfGroups,
       strOutcome = "Score",
@@ -101,7 +106,7 @@ mod_MetricDetails_Server <- function(
 
     mod_MetricTable_Server(
       "analysis_output",
-      rctv_dfResults = rctv_dfResults_byMetricID,
+      rctv_dfResults = rctv_dfResults_Latest,
       dfGroups = dfGroups,
       rctv_strSiteID = rctv_strSiteID
     )

--- a/R/mod_ScatterPlot.R
+++ b/R/mod_ScatterPlot.R
@@ -66,6 +66,12 @@ Widget_ScatterPlot <- function(
     "dfGroups is not a data.frame" = is.null(dfGroups) || is.data.frame(dfGroups),
     "dfBounds is not a data.frame" = is.null(dfBounds) || is.data.frame(dfBounds)
   )
+  if (length(dfResults)) {
+    dfResults <- gsm::FilterByLatestSnapshotDate(dfResults)
+  }
+  if (length(dfBounds)) {
+    dfBounds <- gsm::FilterByLatestSnapshotDate(dfBounds)
+  }
   Widget_Plot(
     "Widget_ScatterPlot",
     id = id,

--- a/R/mod_WidgetPlot.R
+++ b/R/mod_WidgetPlot.R
@@ -89,7 +89,7 @@ mod_WidgetPlot_Server <- function(
     output$plot <- renderWidgetPlot({
       fn_Widget(
         session$ns("plot"),
-        gsm::FilterByLatestSnapshotDate(rctv_dfResults()),
+        rctv_dfResults(),
         lMetric = rctv_lMetric(),
         dfGroups = dfGroups,
         dfBounds = rctv_dfBounds(),

--- a/app.R
+++ b/app.R
@@ -10,12 +10,23 @@ ParticipantProfilePlugin <- plugin_Read(
 plugin_LoadDependencies(aePlugin)
 plugin_LoadDependencies(ParticipantProfilePlugin)
 
+sample_dfBounds2 <- dplyr::mutate(
+  gsm.app::sample_dfBounds,
+  SnapshotDate = lubridate::ymd("2019-10-01")
+)
+sample_dfResults2 <- dplyr::mutate(
+  gsm.app::sample_dfResults,
+  SnapshotDate = lubridate::ymd("2019-10-01")
+)
+
 run_gsm_app(
   dfAnalyticsInput = gsm.app::sample_dfAnalyticsInput,
-  dfBounds = gsm.app::sample_dfBounds,
+  # dfBounds = gsm.app::sample_dfBounds,
+  dfBounds = dplyr::bind_rows(gsm.app::sample_dfBounds, sample_dfBounds2),
   dfGroups = gsm.app::sample_dfGroups,
   dfMetrics = gsm.app::sample_dfMetrics,
-  dfResults = gsm.app::sample_dfResults,
+  # dfResults = gsm.app::sample_dfResults,
+  dfResults = dplyr::bind_rows(gsm.app::sample_dfResults, sample_dfResults2),
   fnFetchData = sample_fnFetchData,
   lPlugins = list(aePlugin, ParticipantProfilePlugin),
   strFavicon = Sys.getenv("GSMAPP_FAVICON", "angles-up"),

--- a/app.R
+++ b/app.R
@@ -12,11 +12,11 @@ plugin_LoadDependencies(ParticipantProfilePlugin)
 
 sample_dfBounds2 <- dplyr::mutate(
   gsm.app::sample_dfBounds,
-  SnapshotDate = lubridate::ymd("2019-10-01")
+  SnapshotDate = as.Date("2019-10-01")
 )
 sample_dfResults2 <- dplyr::mutate(
   gsm.app::sample_dfResults,
-  SnapshotDate = lubridate::ymd("2019-10-01")
+  SnapshotDate = as.Date("2019-10-01")
 )
 
 run_gsm_app(


### PR DESCRIPTION
## Overview
Properly deal with multiple snapshot dates.

## Test Notes/Sample Code
The demo app now has a duplicate copy of the dfResults and dfBounds, with a separate SnapshotDate. Everything other than Time Series should display just the 2019-11-01 copy of the data.

## Connected Issues
- Closes #386