### PR TITLE
Pass plugin args with `rctv_df` prefix

### DIFF
--- a/R/mod_Plugin.R
+++ b/R/mod_Plugin.R
@@ -95,6 +95,16 @@ mod_Plugin_Server <- function(
       )
     )
 
+    # Allow for our formal naming convention in addition to the "base" domain
+    # names.
+    l_rctvPluginData <- c(
+      l_rctvPluginData,
+      rlang::set_names(
+        l_rctvPluginData,
+        paste0("rctv_df", names(l_rctvPluginData))
+      )
+    )
+
     # Other args ----
 
     lOtherArgs <- c(


### PR DESCRIPTION
## Overview
If a plugin function wants `rctf_dfAE` and we have `AE`, we should pass that in. We tend to name things without the prefixes in specs, so I want the flexibility to specify them both ways.

## Test Notes/Sample Code
I'm going to try to leave this open as I implement gsm.ae, in case I have other related things to tweak. I'll push for a review when I'm either done with the gsm.ae push, or when other things move too far away from this.

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #438
