### PR TITLE
Nullify rctvs sent to plugins.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsm.app
 Title: gsm Shiny Application
-Version: 2.4.0.9002
+Version: 2.4.0.9003
 Authors@R: c(
     person("Jon", "Harmon", , "jonthegeek@gmail.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4781-4346")),

--- a/R/mod_GroupDetails.R
+++ b/R/mod_GroupDetails.R
@@ -105,14 +105,14 @@ mod_GroupDetails_Server <- function(
     #
     # nocov start
     observe({
-      if (rctv_strGroupID() == "All") {
-        ## Show placeholders
-        shinyjs::hide("card_group_metadata_list")
-        shinyjs::show("card_placeholder_group_metadata_list")
-      } else {
+      if (length(NullifyEmpty(rctv_strGroupID()))) {
         ## Hide placeholders
         shinyjs::hide("card_placeholder_group_metadata_list")
         shinyjs::show("card_group_metadata_list")
+      } else {
+        ## Show placeholders
+        shinyjs::hide("card_group_metadata_list")
+        shinyjs::show("card_placeholder_group_metadata_list")
       }
     })
     # nocov end

--- a/R/mod_Plugins.R
+++ b/R/mod_Plugins.R
@@ -45,6 +45,75 @@ mod_Plugins_Server <- function(
   # Temporarily skipping tests because the UI works. Need concrete examples to
   # make this make more sense in testing.
   moduleServer(id, function(input, output, session) {
+    # Temporarily do this nullification JUST for plugins while I untangle it
+    # throughout the rest of the app.
+
+    ## Repeated unit to clean up/delete.
+    rctv_dSnapshotDate_Nullified <- reactiveVal(NULL)
+    observe({
+      rctv_dSnapshotDate_Nullified(NullifyEmpty(rctv_dSnapshotDate()))
+    }) %>%
+      bindEvent(rctv_dSnapshotDate())
+    observe({
+      rctv_dSnapshotDate(NullifyEmpty(rctv_dSnapshotDate_Nullified()))
+    }) %>%
+      bindEvent(rctv_dSnapshotDate_Nullified())
+
+    ## Repeated unit to clean up/delete.
+    rctv_strDomainID_Nullified <- reactiveVal(NULL)
+    observe({
+      rctv_strDomainID_Nullified(NullifyEmpty(rctv_strDomainID()))
+    }) %>%
+      bindEvent(rctv_strDomainID())
+    observe({
+      rctv_strDomainID(NullifyEmpty(rctv_strDomainID_Nullified()))
+    }) %>%
+      bindEvent(rctv_strDomainID_Nullified())
+
+    ## Repeated unit to clean up/delete.
+    rctv_strMetricID_Nullified <- reactiveVal(NULL)
+    observe({
+      rctv_strMetricID_Nullified(NullifyEmpty(rctv_strMetricID()))
+    }) %>%
+      bindEvent(rctv_strMetricID())
+    observe({
+      rctv_strMetricID(NullifyEmpty(rctv_strMetricID_Nullified()))
+    }) %>%
+      bindEvent(rctv_strMetricID_Nullified())
+
+    ## Repeated unit to clean up/delete.
+    rctv_strGroupID_Nullified <- reactiveVal(NULL)
+    observe({
+      rctv_strGroupID_Nullified(NullifyEmpty(rctv_strGroupID()))
+    }) %>%
+      bindEvent(rctv_strGroupID())
+    observe({
+      rctv_strGroupID(NullifyEmpty(rctv_strGroupID_Nullified()))
+    }) %>%
+      bindEvent(rctv_strGroupID_Nullified())
+
+    ## Repeated unit to clean up/delete.
+    rctv_strGroupLevel_Nullified <- reactiveVal(NULL)
+    observe({
+      rctv_strGroupLevel_Nullified(NullifyEmpty(rctv_strGroupLevel()))
+    }) %>%
+      bindEvent(rctv_strGroupLevel())
+    observe({
+      rctv_strGroupLevel(NullifyEmpty(rctv_strGroupLevel_Nullified()))
+    }) %>%
+      bindEvent(rctv_strGroupLevel_Nullified())
+
+    ## Repeated unit to clean up/delete.
+    rctv_strSubjectID_Nullified <- reactiveVal(NULL)
+    observe({
+      rctv_strSubjectID_Nullified(NullifyEmpty(rctv_strSubjectID()))
+    }) %>%
+      bindEvent(rctv_strSubjectID())
+    observe({
+      rctv_strSubjectID(NullifyEmpty(rctv_strSubjectID_Nullified()))
+    }) %>%
+      bindEvent(rctv_strSubjectID_Nullified())
+
     if (!is.null(lPlugins)) {
       purrr::imap(
         lPlugins,
@@ -62,12 +131,12 @@ mod_Plugins_Server <- function(
             l_rctvDomains = l_rctvDomains,
             l_rctvDomainHashes = l_rctvDomainHashes,
             l_rctvInputs = list(
-              rctv_dSnapshotDate = rctv_dSnapshotDate,
-              rctv_strDomainID = rctv_strDomainID,
-              rctv_strMetricID = rctv_strMetricID,
-              rctv_strGroupID = rctv_strGroupID,
-              rctv_strGroupLevel = rctv_strGroupLevel,
-              rctv_strSubjectID = rctv_strSubjectID
+              rctv_dSnapshotDate = rctv_dSnapshotDate_Nullified,
+              rctv_strDomainID = rctv_strDomainID_Nullified,
+              rctv_strMetricID = rctv_strMetricID_Nullified,
+              rctv_strGroupID = rctv_strGroupID_Nullified,
+              rctv_strGroupLevel = rctv_strGroupLevel_Nullified,
+              rctv_strSubjectID = rctv_strSubjectID_Nullified
             ),
             chrInputNamesPretty = c(
               "snapshot date",

--- a/R/mod_ScatterPlotSet.R
+++ b/R/mod_ScatterPlotSet.R
@@ -40,10 +40,8 @@ mod_ScatterPlotSet_Server <- function(
         # need to create them for the module to get what it's expecting.
         rctv_lMetric <- reactive({
           lMetric <- as.list(FilterbyMetricID(dfMetrics, strMetricID))
-          strGroupID <- rctv_strGroupID()
-          if (strGroupID != "All") {
-            lMetric$selectedGroupIDs <- strGroupID
-          }
+          strGroupID <- NullifyEmpty(rctv_strGroupID())
+          lMetric$selectedGroupIDs <- strGroupID %||% lMetric$selectedGroupIDs
           lMetric
         })
         rctv_dfResults_byMetricID <- reactive({

--- a/R/srvr_SharedReactives.R
+++ b/R/srvr_SharedReactives.R
@@ -32,11 +32,9 @@ srvr_rctv_lMetric <- function(
   reactive({
     req(rctv_strMetricID())
     lMetric <- rctv_lMetric_base()
-    group <- rctv_strGroupID()
-    if (group != "All") {
-      lMetric$selectedGroupIDs <- group
-    }
-    lMetric
+    lMetric$selectedGroupIDs <- NullifyEmpty(rctv_strGroupID()) %||%
+      lMetric$selectedGroupIDs
+    return(lMetric)
   }) %>%
     bindCache(rctv_strMetricID(), rctv_strGroupID())
 }
@@ -56,8 +54,8 @@ srvr_rctv_chrParticipantIDs <- function(
     .data$SubjectID
   )
   reactive({
-    group <- rctv_strGroupID()
-    if (group == "All") {
+    group <- NullifyEmpty(rctv_strGroupID())
+    if (is.null(group)) {
       return(c("All", dfParticipantGroups$SubjectID))
     }
     c(

--- a/R/utils-wrangle.R
+++ b/R/utils-wrangle.R
@@ -45,7 +45,8 @@ FilterbyMetricID <- function(df, strMetricID) {
 #' @inherit FilterBy return
 #' @keywords internal
 FilterbyGroupID <- function(df, strGroupID) {
-  if (strGroupID == "All") {
+  strGroupID <- NullifyEmpty(strGroupID)
+  if (is.null(strGroupID)) {
     return(df)
   }
   FilterBy(df, strGroupID)


### PR DESCRIPTION
## Overview
Run `NullifyEmpty()` on values going to and from plugins, so plugin authors don't have to deal with that.

## Test Notes/Sample Code
This is a bit hacky, but it covers what I *need* for gsm.ae. See #451, #452 for related improvements.

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #450
