### PR TITLE
Move to rinpharma

### DIFF
--- a/.github/workflows/shinyapps-deploy.yaml
+++ b/.github/workflows/shinyapps-deploy.yaml
@@ -94,7 +94,7 @@ jobs:
           plugin_InstallDependencySources(subjPlugin)
 
           # Manually install rsconnect to deploy.
-          pak::pak("rstudio/rsconnect@v1.3.4")
+          pak::pak("rsconnect")
         shell: Rscript {0}
 
       - name: Set APPNAME
@@ -138,7 +138,7 @@ jobs:
         run: |
           appname <- Sys.getenv("APPNAME")
           rsconnect::setAccountInfo(
-            name = "openrbqm",
+            name = "rinpharma",
             token = Sys.getenv("SHINYAPPSIO_TOKEN"),
             secret = Sys.getenv("SHINYAPPSIO_SECRET")
           )
@@ -153,7 +153,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const appUrl = `https://openrbqm.shinyapps.io/${process.env.APPNAME}`;
+            const appUrl = `https://rinpharma.shinyapps.io/${process.env.APPNAME}`;
             const comment = `🚀 Deployed App: [${appUrl}](${appUrl})`;
 
             await github.rest.issues.createComment({

--- a/.github/workflows/shinyapps-terminate.yaml
+++ b/.github/workflows/shinyapps-terminate.yaml
@@ -35,7 +35,7 @@ jobs:
             sep = "-"
           )
           rsconnect::setAccountInfo(
-            name = "openrbqm",
+            name = "rinpharma",
             token = Sys.getenv("SHINYAPPSIO_TOKEN"),
             secret = Sys.getenv("SHINYAPPSIO_SECRET")
           )
@@ -68,7 +68,7 @@ jobs:
               issue_number: context.issue.number,
             });
 
-            const appUrl = `https://openrbqm.shinyapps.io/${process.env.REPO_NAME}-pr-${process.env.PR_NUMBER}`;
+            const appUrl = `https://rinpharma.shinyapps.io/${process.env.REPO_NAME}-pr-${process.env.PR_NUMBER}`;
             const comment = comments.find(comment =>
               comment.body.includes(appUrl) && comment.user.login === 'github-actions[bot]'
             );

--- a/README.Rmd
+++ b/README.Rmd
@@ -27,10 +27,10 @@ knitr::opts_chunk$set(
 gsm.app produces Shiny applications with drill-down functionality for [`gsm`](https://github.com/Gilead-BioStats/gsm.core) Assessments.
 
 ::: {.pkgdown-release}
-You can explore a sample app produced by the latest release of gsm.app [here](https://openrbqm.shinyapps.io/gsm-app).
+You can explore a sample app produced by the latest release of gsm.app [here](https://rinpharma.shinyapps.io/gsm-app).
 :::
 ::: {.pkgdown-devel}
-You can explore a sample app produced by the development version of gsm.app [here](https://openrbqm.shinyapps.io/gsm-app-dev).
+You can explore a sample app produced by the development version of gsm.app [here](https://rinpharma.shinyapps.io/gsm-app-dev).
 :::
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ gsm.app produces Shiny applications with drill-down functionality for
 <div class="pkgdown-release">
 
 You can explore a sample app produced by the latest release of gsm.app
-[here](https://openrbqm.shinyapps.io/gsm-app).
+[here](https://rinpharma.shinyapps.io/gsm-app).
 
 </div>
 
 <div class="pkgdown-devel">
 
 You can explore a sample app produced by the development version of
-gsm.app [here](https://openrbqm.shinyapps.io/gsm-app-dev).
+gsm.app [here](https://rinpharma.shinyapps.io/gsm-app-dev).
 
 </div>
 


### PR DESCRIPTION
Move from openrbqm.shinyapps.io to rinpharma.shinyapps.io.

Note: I'll get to test out the "workflow_dispatch" version of deployment once we merge to dev; I should be able to use that to redploy the prod app.
