### PR TITLE
Skip BR tests on GitHub Windows runner

### DIFF
--- a/tests/testthat/helper-br.R
+++ b/tests/testthat/helper-br.R
@@ -1,18 +1,29 @@
 # Standard skips ----
 
 skip_if_not_br <- function() {
-  probably_skip_br_tests()
+  maybe_skip_br_tests()
+  skip_on_windows_ci()
   skip_if_not_installed("shinytest2")
   skip_if_not_installed("rvest")
   skip_on_cran()
 }
 
-probably_skip_br_tests <- function() {
+maybe_skip_br_tests <- function() {
   # I'm still including this, but I'd like to TRY to run them all everywhere.
   skip_if_not(
     # as.logical(Sys.getenv("RUN_BR_TESTS", "false")),
     TRUE,
     "BR tests are super slow"
+  )
+}
+
+skip_on_windows_ci <- function() {
+  # Ironically, the tests time out on the Windows runner on GitHub, even
+  # though they run fine on my local Windows machine.
+  skip_if(
+    Sys.info()[["sysname"]] == "Windows" &&
+      isTRUE(as.logical(Sys.getenv("CI", "false"))),
+    "BR tests time out on GitHub Windows runner"
   )
 }
 


### PR DESCRIPTION
## Overview
Skip BR tests on GitHub Windows runner, because they time out.

The tests work fine on my local Windows machine, but something hangs in the GH runner and I haven't been able to identify what.

## Test Notes/Sample Code
 No code has changed outside the tests, and the condition won't trigger in this PR (because we only run the Windows runner on merge to main). So technically this might fail to do what we're aiming at, but we won't know until after we merge this.
